### PR TITLE
Test: Member, OAuth 테스트 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     implementation 'io.github.oshai:kotlin-logging-jvm:7.0.7'
 
     testImplementation 'io.mockk:mockk:1.14.2'
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation 'io.kotest:kotest-assertions-core-jvm:5.9.1'
     testImplementation 'io.kotest:kotest-runner-junit5-jvm:5.9.1'

--- a/backend/src/main/java/project/backend/auth/app/OAuthSignUpService.kt
+++ b/backend/src/main/java/project/backend/auth/app/OAuthSignUpService.kt
@@ -11,11 +11,11 @@ import project.backend.domain.imagefile.ImageFileService
 @Service
 class OAuthSignUpService(
     private val memberRepository: MemberRepository,
-    private val imageFileService: ImageFileService
-) {
+    private val imageFileService: ImageFileService,
 
     @Value("\${file.images.profile.default}")
-    private lateinit var defaultProfileImg: String
+    private val defaultProfileImg: String
+) {
 
     fun oAuthSignUp(request: OAuthMemberDto): Member {
         return memberRepository.findByUsername(request.login)

--- a/backend/src/main/java/project/backend/domain/member/app/MemberService.kt
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberService.kt
@@ -33,10 +33,10 @@ class MemberService (
     private val passwordEncoder: PasswordEncoder,
     private val eventPublisher: ApplicationEventPublisher,
 
-){
     @Value("\${file.images.profile.default}")
-    private lateinit var defaultProfileImg: String
+    private val defaultProfileImg: String
 
+){
     fun saveMember(request: SignUpRequest): MemberResponse {
         if (checkUsernameAlreadyExists(request.username)) {
             throw MemberException(MemberErrorCode.USERNAME_ALREADY_EXISTS)

--- a/backend/src/main/java/project/backend/domain/member/dto/SignUpRequest.kt
+++ b/backend/src/main/java/project/backend/domain/member/dto/SignUpRequest.kt
@@ -32,5 +32,5 @@ data class SignUpRequest (
         min = 4,
         message = "비밀번호는 최소 4자 이상이여야 합니다."
     )
-    var password: String
+    var password: String? = null
 )

--- a/backend/src/main/java/project/backend/domain/member/entity/Member.kt
+++ b/backend/src/main/java/project/backend/domain/member/entity/Member.kt
@@ -10,7 +10,7 @@ class Member (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
-    val id: Long? = null,
+    var id: Long? = null,
 
     @Column(nullable = false, unique = true)
     var username: String,

--- a/backend/src/test/java/project/backend/auth/app/OAuthSignUpServiceTests.kt
+++ b/backend/src/test/java/project/backend/auth/app/OAuthSignUpServiceTests.kt
@@ -1,0 +1,85 @@
+package project.backend.auth.app
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import project.backend.auth.dto.OAuthMemberDto
+import project.backend.domain.member.dao.MemberRepository
+import project.backend.domain.member.entity.ProviderType
+import project.backend.domain.member.mapper.MemberMapper
+import project.backend.domain.imagefile.ImageFileService
+
+class OAuthSignUpServiceTests : BehaviorSpec({
+
+    Given("OAuth 로그인 - 새로운 유저일 때") {
+        val memberRepository = mockk<MemberRepository>(relaxed = true)
+        val imageFileService = mockk<ImageFileService>()
+        val oAuthSignUpService = OAuthSignUpService(
+            memberRepository,
+            imageFileService,
+            defaultProfileImg = "defaultProfileImage.png"
+        )
+
+        val request = OAuthMemberDto(
+            login = "memberGitHub",
+            email = "memberGitHub@gmail.com",
+            nickname = "githubNickname"
+        )
+
+        every { memberRepository.findByUsername(request.login) } returns null
+        every { memberRepository.save(any()) } answers {
+            val saved = firstArg<project.backend.domain.member.entity.Member>()
+            saved.id = 1L
+            saved
+        }
+
+        When("oAuthSignUp 호출 시") {
+            val result = oAuthSignUpService.oAuthSignUp(request)
+
+            Then("새로운 Member가 저장된다.") {
+                result.username shouldBe request.login
+                result.email shouldBe request.email
+                result.nickname shouldBe request.nickname
+                result.provider shouldBe ProviderType.GITHUB
+                result.profileImage shouldBe "defaultProfileImage.png"
+
+                verify(exactly = 1) { memberRepository.save(any()) }
+            }
+        }
+    }
+
+    Given("OAuth 로그인 - 기존 유저가 있을 때") {
+        val memberRepository = mockk<MemberRepository>(relaxed = true)
+        val imageFileService = mockk<ImageFileService>()
+        val oAuthSignUpService = OAuthSignUpService(
+            memberRepository,
+            imageFileService,
+            defaultProfileImg = "defaultProfileImage.png"
+        )
+
+        val request = OAuthMemberDto(
+            login = "existingGithubUser",
+            email = "existingUser@gmail.com",
+            nickname = "existingNickname"
+        )
+
+        val existingMember = MemberMapper.toEntity(request, "defaultProfileImage.png").apply {
+            id = 1L
+        }
+
+        every { memberRepository.findByUsername(request.login) } returns existingMember
+        every { memberRepository.save(any()) } throws AssertionError("save should not be called!")
+
+        When("oAuthSignUp 호출 시") {
+            val result = oAuthSignUpService.oAuthSignUp(request)
+
+            Then("기존 Member가 반환된다.") {
+                result shouldBe existingMember
+            }
+        }
+
+        verify(exactly = 0) { memberRepository.save(any()) }
+    }
+})

--- a/backend/src/test/java/project/backend/domain/member/MemberIntegrationTest.kt
+++ b/backend/src/test/java/project/backend/domain/member/MemberIntegrationTest.kt
@@ -1,0 +1,72 @@
+package project.backend.domain.member
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.transaction.annotation.Transactional
+import project.backend.domain.member.dao.MemberRepository
+import project.backend.domain.member.dto.SignUpRequest
+import project.backend.domain.member.entity.ProviderType
+import project.backend.global.security.config.TestSecurityConfig
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig::class) // 테스트 전용 SecurityConfig (permitAll 설정)
+class MemberIntegrationTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var memberRepository: MemberRepository
+
+    @Test
+    @WithMockUser // 인증된 사용자로 요청 (Security 필터 통과)
+    fun `폼 회원가입 요청시 CREATED(201) 반환 및 DB 저장 확인`() {
+        // given
+        val request = SignUpRequest(
+            username = "member1",
+            nickname = "nickname1",
+            email = "member1@gmail.com",
+            password = "1234"
+        )
+
+        // when
+        mockMvc.post("/signup") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }
+            .andExpect {
+                status { isCreated() }
+                content { contentType(MediaType.APPLICATION_JSON) }
+                jsonPath("$.username") { value(request.username) }
+                jsonPath("$.nickname") { value(request.nickname) }
+                jsonPath("$.email") { value(request.email) }
+                jsonPath("$.profileImg") { value("default-profile.png") }
+                jsonPath("$.provider") { value(ProviderType.LOCAL.name) }
+            }
+
+        // then - DB 저장 값 검증
+        val member = memberRepository.findByEmail(request.email!!)
+        assertThat(member).isNotNull
+        assertThat(member!!.username).isEqualTo(request.username)
+        assertThat(member.nickname).isEqualTo(request.nickname)
+        assertThat(member.email).isEqualTo(request.email)
+        assertThat(member.provider).isEqualTo(ProviderType.LOCAL)
+        assertThat(member.profileImage).isEqualTo("default-profile.png")
+    }
+}

--- a/backend/src/test/java/project/backend/domain/member/api/SignupControllerTests.kt
+++ b/backend/src/test/java/project/backend/domain/member/api/SignupControllerTests.kt
@@ -1,0 +1,78 @@
+package project.backend.domain.member.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithMockUser
+import project.backend.auth.token.jwt.JwtProvider
+import project.backend.domain.member.app.MemberService
+import project.backend.domain.member.dto.MemberResponse
+import project.backend.domain.member.dto.SignUpRequest
+import project.backend.domain.member.entity.ProviderType
+import project.backend.global.security.config.TestSecurityConfig
+
+@WebMvcTest(
+    controllers = [SignupController::class]
+)
+@Import(TestSecurityConfig::class)
+class SignupControllerTests {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var memberService: MemberService
+
+    @Autowired
+    lateinit var om: ObjectMapper
+
+    @MockitoBean
+    lateinit var jwtProvider: JwtProvider
+
+    @Test
+    @WithMockUser
+    fun `폼 회원가입 요청 및 성공시 CREATED(201), MemberResponse 반환 테스트`() {
+        // given
+        val request = SignUpRequest(
+            username = "member1",
+            nickname = "nickname1",
+            email = "member1@gmail.com",
+            password = "1234"
+        )
+
+        val expectedResponse = MemberResponse(
+            id = 1L,
+            username = request.username,
+            nickname = request.nickname,
+            email = request.email,
+            profileImg = "defaultProfileImage.png",
+            provider = ProviderType.LOCAL
+        )
+
+        `when`(memberService.saveMember(request)).thenReturn(expectedResponse)
+
+        // when, then
+        mockMvc.post("/signup") {
+            contentType = MediaType.APPLICATION_JSON
+            content = om.writeValueAsString(request)
+        }
+            .andExpect {
+                status { isCreated() }
+                content { contentType(MediaType.APPLICATION_JSON) }
+                jsonPath("$.id") { value(expectedResponse.id) }
+                jsonPath("$.username") { value(expectedResponse.username) }
+                jsonPath("$.nickname") { value(expectedResponse.nickname) }
+                jsonPath("$.email") { value(expectedResponse.email) }
+                jsonPath("$.profileImg") { value(expectedResponse.profileImg) }
+                jsonPath("$.provider") { value(expectedResponse.provider.name) }
+            }
+            .andDo { print() }
+    }
+}

--- a/backend/src/test/java/project/backend/domain/member/app/MemberServiceTests.kt
+++ b/backend/src/test/java/project/backend/domain/member/app/MemberServiceTests.kt
@@ -1,0 +1,115 @@
+package project.backend.domain.member.app
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.* // clearAllMocks(), mockk() 를 위해 필요
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.security.crypto.password.PasswordEncoder
+import project.backend.domain.imagefile.ImageFileService
+import project.backend.domain.member.dao.MemberRepository
+import project.backend.domain.member.dto.SignUpRequest
+import project.backend.domain.member.entity.Member
+import project.backend.domain.member.entity.ProviderType
+import project.backend.global.exception.errorcode.MemberErrorCode
+import project.backend.global.exception.ex.MemberException
+
+class MemberServiceTests : BehaviorSpec({
+
+    Given("Form 회원가입 테스트 진행") {
+        val memberRepository: MemberRepository = mockk(relaxed = true)
+        val imageFileService: ImageFileService = mockk()
+        val passwordEncoder: PasswordEncoder = mockk()
+        val eventPublisher: ApplicationEventPublisher = mockk()
+
+        val memberService = MemberService(
+            memberRepository,
+            imageFileService,
+            passwordEncoder,
+            eventPublisher,
+            defaultProfileImg = "defaultProfileImage.png"
+        )
+
+        val request = SignUpRequest(
+            username = "member1",
+            nickname = "member1Nickname",
+            email = "member1@gmail.com",
+            password = "1234",
+        )
+
+        val encryptedPassword = "encryptedPassword"
+
+        every { memberRepository.findByUsername(request.username) } returns null
+        every { memberRepository.findByEmail(request.email!!) } returns null
+        every { passwordEncoder.encode(request.password) } returns encryptedPassword
+
+        every { memberRepository.save(any()) } answers {
+            val saved = firstArg<Member>()
+            saved.id = 1L
+            saved
+        }
+
+        When("save를 호출 시") {
+            val response = memberService.saveMember(request)
+
+            Then("정상적으로 회원값이 반환된다.") {
+                response.username shouldBe request.username
+                response.nickname shouldBe request.nickname
+                response.email shouldBe request.email
+                response.profileImg shouldBe "defaultProfileImage.png"
+                response.provider shouldBe ProviderType.LOCAL
+
+                // 이 테스트에서 save가 1번 호출되었음을 검증.
+                verify(exactly = 1) { memberRepository.save(any()) }
+                verify { passwordEncoder.encode(request.password) }
+            }
+        }
+    }
+
+    Given("Form 회원가입 - 회원가입 시도 email이 존재하는 경우") {
+        // 두 번째 Given 블록에서도 독립적으로 Mock 객체와 SUT를 선언하고 초기화합니다.
+        val memberRepository: MemberRepository = mockk(relaxed = true)
+        val imageFileService: ImageFileService = mockk()
+        val passwordEncoder: PasswordEncoder = mockk()
+        val eventPublisher: ApplicationEventPublisher = mockk()
+
+        val memberService = MemberService(
+            memberRepository,
+            imageFileService,
+            passwordEncoder,
+            eventPublisher,
+            defaultProfileImg = "default-profile.png"
+        )
+
+        val request = SignUpRequest(
+            username = "newUser",
+            nickname = "nickname",
+            email = "existingEmail@gmail.com",
+            password = "1234"
+        )
+
+        val existingMember = Member(
+            username = "existingUser",
+            password = "encryptedPassword",
+            nickname = "nickname",
+            email = request.email!!,
+            provider = ProviderType.LOCAL,
+            profileImage = "default-profile.png"
+        ).apply { id = 1L }
+
+        every { memberRepository.findByUsername(request.username) } returns null
+        every { memberRepository.findByEmail(request.email!!) } returns existingMember
+
+        When("saveMember 호출 시") {
+            Then("MemberException(EMAIL_ALREADY_EXISTS) 예외가 발생한다.") {
+                val exception = runCatching { memberService.saveMember(request) }.exceptionOrNull()
+
+                exception.shouldBeInstanceOf<MemberException>()
+                exception.message shouldBe MemberErrorCode.EMAIL_ALREADY_EXISTS.message
+
+                // 이 테스트에서 save가 0번 호출되었음을 검증.
+                verify(exactly = 0) { memberRepository.save(any()) }
+            }
+        }
+    }
+})

--- a/backend/src/test/java/project/backend/domain/member/dao/MemberRepositoryTests.kt
+++ b/backend/src/test/java/project/backend/domain/member/dao/MemberRepositoryTests.kt
@@ -1,0 +1,59 @@
+package project.backend.domain.member.dao
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import project.backend.domain.member.entity.Member
+import project.backend.domain.member.entity.ProviderType
+
+@DataJpaTest
+class MemberRepositoryTests @Autowired constructor(
+    val memberRepository: MemberRepository
+){
+
+    @Test
+    fun `findByEmail 유효한 Member 반환 테스트`() {
+        val member = Member(
+            username = "member1",
+            nickname = "member1Nickname",
+            email = "member1@gmail.com",
+            password = "1234",
+            provider = ProviderType.GITHUB,
+            profileImage = "defaultProfileImage"
+        )
+        memberRepository.save(member)
+        val findMember = memberRepository.findByEmail("member1@gmail.com")
+        assertEquals(member.username, findMember?.username)
+    }
+
+    @Test
+    fun `findByEmail null값 반환 테스트`() {
+        val found = memberRepository.findByEmail("null@example.com")
+        assertNull(found)
+    }
+
+    @Test
+    fun `findByUsername 유효한 Member 반환 테스트`() {
+        val member = Member(
+            username = "member1",
+            nickname = "member1Nickname",
+            email = "member1@gmail.com",
+            password = "1234",
+            provider = ProviderType.GITHUB,
+            profileImage = "defaultProfileImage"
+        )
+        memberRepository.save(member)
+
+        val found = memberRepository.findByUsername("member1")
+        assertEquals(member.email, found?.email)
+    }
+
+    @Test
+    fun `findByUsername null 반환 테스트`() {
+        val found = memberRepository.findByEmail("null@example.com")
+        assertNull(found)
+    }
+
+}

--- a/backend/src/test/java/project/backend/global/security/config/TestSecurityConfig.kt
+++ b/backend/src/test/java/project/backend/global/security/config/TestSecurityConfig.kt
@@ -1,0 +1,19 @@
+package project.backend.global.security.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@TestConfiguration
+class TestSecurityConfig {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .securityMatcher("/signup")
+            .csrf { it.disable() }
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+            .build()
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,79 @@
+spring:
+  session:
+    store-type: none
+
+  datasource:
+    url: jdbc:h2:mem:db;MODE=MYSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  flyway:
+    enabled: false
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_SECRET}
+            scope:
+              - repo
+              - admin:repo_hook
+              - user
+        provider:
+          github:
+            user-name-attribute: login
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+file:
+  images:
+    profile:
+      path: images/profile/
+      default: default-profile.png
+      github: github-profile.png
+    chat:
+      path: images/chat/
+
+github:
+  username: GitHubBot
+
+url:
+  ngrok: ${NGROK_URL}
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: devchat-images
+
+
+jwt:
+  redirection:
+    base: http://localhost:3000/
+
+  info:
+    issuer: "대한민국26세 달성 배씨 배문성의 허가가 있는 토큰이올시다."
+    secret: 36b2294c1079470409d860ac57402fc152524d134a75b7cb223d92644b63adba980d90dcefd0d53c02a5cbb43c2678d49128dae2299f652f5f71033fee640686


### PR DESCRIPTION
## 🛰️ Issue Number
#11 

## 🪐 작업 내용
- ### Member 단위 테스트
    #### **[MemberRepository 단위 테스트]**
    - findByEmail 유효한 Member 반환 테스트
    - findByEmail null값 반환 테스트
    - findByUsername 유효한 Member 반환 테스트
    - findByUsername null 반환 테스트
    #### **[MemberService 단위 테스트]**
    - Form 가입 시, 새로운 Member인 경우 정상값 반환 및 save메서드 1회 호출 테스트
    - Form 가입 시, email이 존재하는 경우, save메서드 0회 호출 테스트
    #### **[SignupController 단위 테스트]**
    - 폼 회원가입 요청 및 성공시 CREATED(201), MemberResponse 반환 테스트
- ### OAuth 단위 테스트
    #### **[OAuthSignupService 단위 테스트]**
    - OAuth 로그인 - 새로운 Member인 경우 정상값 반환 및 save 1회 호출 테스트
    - OAuth 로그인 - 기존 유저가 존재하는 경우, 기존 멤버값 반환 및 save 0회 테스트
- ### 회원가입 통합 테스트
    - 컨트롤러부터 DB까지 검증 (SpringSecurity 검증 제외)

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?