### PR TITLE
Test: ChatRoom 단위테스트(Repository, Service)

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.kt
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.kt
@@ -193,7 +193,7 @@ class ChatRoomService @Autowired constructor(
         updateRecentRoomAfterLeaving(memberId)
     }
 
-    private fun updateRecentRoomAfterLeaving(memberId: Long) {
+    fun updateRecentRoomAfterLeaving(memberId: Long) {
         val member = memberService.getMemberById(memberId)
 
         val mostRecentActiveRoom = chatParticipantRepository

--- a/backend/src/main/java/project/backend/domain/chat/github/GitHubBotInitializer.kt
+++ b/backend/src/main/java/project/backend/domain/chat/github/GitHubBotInitializer.kt
@@ -21,6 +21,7 @@ class GitHubBotInitializer(
 
     @PostConstruct
     fun init() {
+
         val gitHubBot = Member(
             username = githubUsername,
             nickname = githubUsername,

--- a/backend/src/test/java/project/backend/chatroom/api/ChatRoomControllerTests.kt
+++ b/backend/src/test/java/project/backend/chatroom/api/ChatRoomControllerTests.kt
@@ -1,0 +1,4 @@
+package project.backend.chatroom.api
+
+class ChatRoomControllerTests {
+}

--- a/backend/src/test/java/project/backend/chatroom/api/ChatRoomControllerTests.kt
+++ b/backend/src/test/java/project/backend/chatroom/api/ChatRoomControllerTests.kt
@@ -1,4 +1,0 @@
-package project.backend.chatroom.api
-
-class ChatRoomControllerTests {
-}

--- a/backend/src/test/java/project/backend/chatroom/app/ChatRoomServiceTests.kt
+++ b/backend/src/test/java/project/backend/chatroom/app/ChatRoomServiceTests.kt
@@ -8,11 +8,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationEventPublisher
 import project.backend.chatroom.util.createChatRoom
 import project.backend.chatroom.util.createMember
+import project.backend.chatroom.util.createParticipant
 import project.backend.domain.chat.chatroom.app.ChatRoomService
 import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository
 import project.backend.domain.chat.chatroom.dto.ChatRoomRequest
 import project.backend.domain.chat.chatroom.dto.ChatRoomSimpleResponse
+import project.backend.domain.chat.chatroom.dto.event.DeleteChatRoomEvent
 import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent
 import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent
 import project.backend.domain.chat.chatroom.entity.ChatParticipant
@@ -22,9 +24,11 @@ import project.backend.domain.chat.github.app.GitMessageService
 import project.backend.domain.member.app.MemberService
 import project.backend.domain.member.entity.Member
 import project.backend.domain.member.entity.ProviderType
+import project.backend.global.exception.errorcode.ChatRoomErrorCode
 import project.backend.global.exception.ex.ChatRoomException
 import java.time.LocalDateTime
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ChatRoomServiceTests {
 
@@ -175,6 +179,148 @@ class ChatRoomServiceTests {
         }
     }
 
+    @Test
+    fun `채팅방에 참여하지 않은 사용자가 나가려고 하면 예외 발생`() {
+        // given
+        val roomId = 1L
+        val memberId = 2L
+
+        every {
+            chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId,
+                memberId
+            )
+        } returns null
+
+        // when & then
+        assertThrows<ChatRoomException> {
+            service.leaveChatRoom(roomId, memberId)
+        }.also {
+            assertEquals(ChatRoomErrorCode.NOT_PARTICIPANT, it.errorCode)
+        }
+    }
+
+    @Test
+    fun `방장이 채팅방을 나가려고 하면 예외 발생`() {
+        // given
+        val roomId = 1L
+        val memberId = 2L
+
+        val member = createMember(id = memberId)
+        val chatRoom = createChatRoom(id = roomId)
+        val ownerParticipant =
+            createParticipant(
+                chatRoom = chatRoom,
+                member = member,
+                owner = true,
+                joinAt = LocalDateTime.now()
+            )
+
+        every {
+            chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId,
+                memberId
+            )
+        } returns ownerParticipant
+
+        // when & then
+        assertThrows<ChatRoomException> {
+            service.leaveChatRoom(roomId, memberId)
+        }.also {
+            assertEquals(ChatRoomErrorCode.OWNER_CANNOT_LEAVE, it.errorCode)
+        }
+    }
+
+    @Test
+    fun `방장이 채팅방을 정상적으로 삭제`() {
+        // given
+        val roomId = 1L
+        val memberId = 2L
+
+        val member = createMember(id = memberId)
+        val chatRoom = createChatRoom(id = roomId, name = "DeletingRoom")
+        val ownerParticipant =
+            createParticipant(
+                chatRoom = chatRoom,
+                member = member,
+                owner = true,
+                joinAt = LocalDateTime.now()
+            )
+
+        every {
+            chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId,
+                memberId
+            )
+        } returns ownerParticipant
+        every { service.getRoomById(roomId) } returns chatRoom
+        every { eventPublisher.publishEvent(any()) } just Runs
+        every { chatRoomRepository.delete(chatRoom) } just Runs
+
+        // when
+        service.deleteChatRoom(roomId, memberId)
+
+        // then
+        verify {
+            eventPublisher.publishEvent(
+                match<DeleteChatRoomEvent> {
+                    it.roomId == roomId &&
+                            it.roomName == "DeletingRoom"
+                })
+        }
+        verify { chatRoomRepository.delete(chatRoom) }
+    }
+
+    @Test
+    fun `방장이 아닌 사용자가 삭제 시도 시 예외 발생`() {
+        // given
+        val roomId = 1L
+        val memberId = 2L
+
+        val member = createMember(id = memberId)
+        val chatRoom = createChatRoom(id = roomId, name = "DeletingRoom")
+        val ownerParticipant =
+            createParticipant(
+                chatRoom = chatRoom,
+                member = member,
+                owner = false,
+                joinAt = LocalDateTime.now()
+            )
+        every { service.getRoomById(roomId) } returns chatRoom
+        every {
+            chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId,
+                memberId
+            )
+        } returns ownerParticipant
+
+        // when & then
+        assertThrows<ChatRoomException> {
+            service.deleteChatRoom(roomId, memberId)
+        }.also {
+            assertEquals(ChatRoomErrorCode.OWNER_PERMISSION_REQUIRED, it.errorCode)
+        }
+    }
+
+    @Test
+    fun `채팅방 참여자가 아닌 사용자가 삭제 시도 시 예외 발생`() {
+        // given
+        val memberId = 100L
+        val roomId = 1L
+        val chatRoom = createChatRoom(id = roomId, name = "DeletingRoom")
 
 
+        every { service.getRoomById(roomId) } returns chatRoom
+        every {
+            chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId,
+                memberId
+            )
+        } returns null
+
+        // when & then
+        assertThrows<ChatRoomException> {
+            service.deleteChatRoom(roomId, memberId)
+        }. also { assertEquals(ChatRoomErrorCode.NOT_PARTICIPANT, it.errorCode) }
+    }
 }

--- a/backend/src/test/java/project/backend/chatroom/app/ChatRoomServiceTests.kt
+++ b/backend/src/test/java/project/backend/chatroom/app/ChatRoomServiceTests.kt
@@ -1,23 +1,29 @@
 package project.backend.chatroom.app
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.assertThrows
+import org.springframework.boot.json.JsonWriter
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationEventPublisher
+import project.backend.chatroom.util.createChatRoom
 import project.backend.chatroom.util.createMember
 import project.backend.domain.chat.chatroom.app.ChatRoomService
 import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository
 import project.backend.domain.chat.chatroom.dto.ChatRoomRequest
 import project.backend.domain.chat.chatroom.dto.ChatRoomSimpleResponse
+import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent
+import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent
+import project.backend.domain.chat.chatroom.entity.ChatParticipant
 import project.backend.domain.chat.chatroom.entity.ChatRoom
 import project.backend.domain.chat.chatroom.mapper.ChatRoomMapper
 import project.backend.domain.chat.github.app.GitMessageService
 import project.backend.domain.member.app.MemberService
 import project.backend.domain.member.entity.Member
 import project.backend.domain.member.entity.ProviderType
+import project.backend.global.exception.ex.ChatRoomException
+import java.time.LocalDateTime
 import kotlin.test.Test
 
 class ChatRoomServiceTests {
@@ -27,7 +33,7 @@ class ChatRoomServiceTests {
     val chatRoomMapper = mockk<ChatRoomMapper>()
     val memberService = mockk<MemberService>()
     val gitMessageService = mockk<GitMessageService>()
-    val eventPublisher = mockk<ApplicationEventPublisher>()
+    val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
 
     val service = ChatRoomService(
         chatRoomRepository,
@@ -63,7 +69,13 @@ class ChatRoomServiceTests {
             10L, "채팅방", "https://github.com/repo", member.id!!, "INVITE123"
         )
         every { chatRoomRepository.save(chatRoom) } returns chatRoom
-        every { gitMessageService.registerWebhook("https://github.com/repo", 10L, 1L) } returns Unit // 추가
+        every {
+            gitMessageService.registerWebhook(
+                "https://github.com/repo",
+                10L,
+                1L
+            )
+        } returns Unit // 추가
 
         // when
         val response = service.createChatRoom(request, 1L)
@@ -74,14 +86,95 @@ class ChatRoomServiceTests {
     }
 
 
+    @Test
+    fun `초대코드로 채팅방 참여 성공 테스트`() {
+        // given
+        val inviteCode = "JOIN777"
+        val memberId = 1L
 
-//    @Test
-//    fun `채팅방 참여 테스트`() {
-//        //given
-//        val member = Member(
-//            id = 1L,
-//
-//            )
-//    }
+        val chatRoom = createChatRoom(
+            name = "조인할 채팅방",
+            repositoryUrl = "https://github.com/repo",
+            id = 1L,
+            inviteCode = inviteCode
+        )
+        val member = createMember(id = 1L, username = "User", profileImage = "img.png")
+
+        every { chatRoomRepository.findByInviteCode(inviteCode) } returns chatRoom
+        every { memberService.getMemberById(memberId) } returns member
+        every { chatParticipantRepository.save(any()) } answers { firstArg() }
+        every {
+            chatParticipantRepository.findByChatRoomIdAndParticipantId(
+                any(),
+                any()
+            )
+        } returns null
+        every { eventPublisher.publishEvent(any()) } just Runs
+
+        // when
+        val response = service.joinChatRoom(inviteCode, memberId)
+
+        // then
+        assertThat(response.inviteCode).isEqualTo(inviteCode)
+    }
+
+    @Test
+    fun `잘못된 초대코드로 채팅방 참여시 실패`() {
+        // given
+        val invalidCode = "WRONG_CODE"
+        val memberId = 1L
+
+        every { chatRoomRepository.findByInviteCode(invalidCode) } returns null
+
+        // when & then
+        assertThrows<ChatRoomException> {
+            service.joinChatRoom(invalidCode, memberId)
+        }
+    }
+
+    @Test
+    fun `채팅방에서 정상적으로 퇴장하면 이벤트가 발행되고 최근방이 갱신된다`() {
+        // given
+        val roomId = 1L
+        val memberId = 100L
+
+        val participant = mockk<ChatParticipant>(relaxed = true)
+        every { participant.owner } returns false
+        every { participant.leave() } just Runs
+
+        every {
+            chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId, memberId
+            )
+        } returns participant
+
+        val member = mockk<Member>(relaxed = true)
+        every { member.nickname } returns "test"
+        every { memberService.getMemberById(memberId) } returns member
+        every {
+            chatParticipantRepository.findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
+                memberId
+            )
+        } returns null
+
+        every { eventPublisher.publishEvent(any()) } just Runs
+
+        // when
+        service.leaveChatRoom(roomId, memberId)
+
+        // then
+        verify { participant.leave() }
+        verify {
+            eventPublisher.publishEvent(
+                match<LeaveChatRoomEvent> {
+                    it.roomId == roomId &&
+                            it.memberId == memberId &&
+                            it.nickname == "test"
+                }
+            )
+        }
+    }
+
+
 
 }

--- a/backend/src/test/java/project/backend/chatroom/app/ChatRoomServiceTests.kt
+++ b/backend/src/test/java/project/backend/chatroom/app/ChatRoomServiceTests.kt
@@ -1,0 +1,87 @@
+package project.backend.chatroom.app
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationEventPublisher
+import project.backend.chatroom.util.createMember
+import project.backend.domain.chat.chatroom.app.ChatRoomService
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository
+import project.backend.domain.chat.chatroom.dto.ChatRoomRequest
+import project.backend.domain.chat.chatroom.dto.ChatRoomSimpleResponse
+import project.backend.domain.chat.chatroom.entity.ChatRoom
+import project.backend.domain.chat.chatroom.mapper.ChatRoomMapper
+import project.backend.domain.chat.github.app.GitMessageService
+import project.backend.domain.member.app.MemberService
+import project.backend.domain.member.entity.Member
+import project.backend.domain.member.entity.ProviderType
+import kotlin.test.Test
+
+class ChatRoomServiceTests {
+
+    val chatRoomRepository = mockk<ChatRoomRepository>()
+    val chatParticipantRepository = mockk<ChatParticipantRepository>()
+    val chatRoomMapper = mockk<ChatRoomMapper>()
+    val memberService = mockk<MemberService>()
+    val gitMessageService = mockk<GitMessageService>()
+    val eventPublisher = mockk<ApplicationEventPublisher>()
+
+    val service = ChatRoomService(
+        chatRoomRepository,
+        chatParticipantRepository,
+        chatRoomMapper,
+        memberService,
+        gitMessageService,
+        eventPublisher,
+        githubUsername = "GitHubBot"
+    )
+
+    @Test
+    fun `채팅방 생성 시 참여자 등록 및 깃허브 봇 참가`() {
+        // given
+        val member = Member(
+            id = 1L,
+            username = "userA",
+            nickname = "User",
+            provider = ProviderType.LOCAL,
+            profileImage = "img.png"
+        )
+        val request = ChatRoomRequest("채팅방", "https://github.com/repo")
+
+        val chatRoom = mockk<ChatRoom>(relaxed = true)
+        every { chatRoom.id } returns 10L
+        every { chatRoom.name } returns "채팅방"
+        every { chatRoom.inviteCode } returns "INVITE123"
+
+        every { memberService.getMemberById(1L) } returns member
+        every { memberService.getMemberByUsername("GitHubBot") } returns mockk(relaxed = true) // 수정
+        every { chatRoomMapper.toEntity(request) } returns chatRoom
+        every { chatRoomMapper.toSimpleResponse(any(), any()) } returns ChatRoomSimpleResponse(
+            10L, "채팅방", "https://github.com/repo", member.id!!, "INVITE123"
+        )
+        every { chatRoomRepository.save(chatRoom) } returns chatRoom
+        every { gitMessageService.registerWebhook("https://github.com/repo", 10L, 1L) } returns Unit // 추가
+
+        // when
+        val response = service.createChatRoom(request, 1L)
+
+        // then
+        assertThat(response.name).isEqualTo("채팅방")
+        verify { gitMessageService.registerWebhook("https://github.com/repo", 10L, 1L) }
+    }
+
+
+
+//    @Test
+//    fun `채팅방 참여 테스트`() {
+//        //given
+//        val member = Member(
+//            id = 1L,
+//
+//            )
+//    }
+
+}

--- a/backend/src/test/java/project/backend/chatroom/dao/ChatRoomRepositoryTests.kt
+++ b/backend/src/test/java/project/backend/chatroom/dao/ChatRoomRepositoryTests.kt
@@ -36,7 +36,7 @@ class ChatRoomRepositoryTests @Autowired constructor(
         val member = memberRepository.save(createMember(id = 1L, username = "userSave"))
 
         // when
-        val room = chatRoomRepository.save(createChatRoom(name = "참여방"))
+        val room = chatRoomRepository.save(createChatRoom(id = 2L, name = "참여방"))
         val participant = participantRepository.save(createParticipant(member, room))
 
         // then
@@ -53,7 +53,7 @@ class ChatRoomRepositoryTests @Autowired constructor(
     fun `참여자 ID로 채팅방 조회 테스트`() {
         // given
         val member = memberRepository.save(createMember(id = 2L, username = "userRead"))
-        val room = chatRoomRepository.save(createChatRoom(name = "참여방"))
+        val room = chatRoomRepository.save(createChatRoom(id = 2L, name = "참여방"))
         val participant = participantRepository.save(createParticipant(member, room))
 
         // when
@@ -71,7 +71,7 @@ class ChatRoomRepositoryTests @Autowired constructor(
     fun `초대코드로 채팅방 조회 테스트`() {
         //given
         val inviteCode = "JOIN777"
-        val room = chatRoomRepository.save(createChatRoom(name = "채팅방", inviteCode = inviteCode))
+        val room = chatRoomRepository.save(createChatRoom(name = "채팅방", id=3L,inviteCode = inviteCode))
 
         //when
         val found = chatRoomRepository.findByInviteCode(inviteCode)
@@ -85,8 +85,8 @@ class ChatRoomRepositoryTests @Autowired constructor(
     fun `Owner id로 내가 만든 채팅방 조회 테스트`() {
         //given
         val owner = memberRepository.save(createMember(id= 3L, username = "ownerA"))
-        val room1 = chatRoomRepository.save(createChatRoom(name = "Room A"))
-        val room2 = chatRoomRepository.save(createChatRoom(name = "Room B"))
+        val room1 = chatRoomRepository.save(createChatRoom(id = 3L, name = "Room A"))
+        val room2 = chatRoomRepository.save(createChatRoom(id = 4L, name = "Room B"))
         participantRepository.save(createParticipant(owner, room1, owner = true))
         participantRepository.save(createParticipant(owner, room2, owner = true))
 

--- a/backend/src/test/java/project/backend/chatroom/dao/ChatRoomRepositoryTests.kt
+++ b/backend/src/test/java/project/backend/chatroom/dao/ChatRoomRepositoryTests.kt
@@ -1,19 +1,26 @@
 package project.backend.chatroom.dao
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.assertj.core.api.Assertions
-import org.assertj.core.api.Assertions.assertThat
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+import project.backend.chatroom.util.createChatRoom
+import project.backend.chatroom.util.createMember
+import project.backend.chatroom.util.createParticipant
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository
-
+import project.backend.domain.member.dao.MemberRepository
 
 private val log = KotlinLogging.logger {}
 
 @SpringBootTest
 class ChatRoomRepositoryTests @Autowired constructor(
-    val chatRoomRepository: ChatRoomRepository
+    val chatRoomRepository: ChatRoomRepository,
+    val memberRepository: MemberRepository,
+    val participantRepository: ChatParticipantRepository
 ) {
 
     @Test
@@ -22,4 +29,72 @@ class ChatRoomRepositoryTests @Autowired constructor(
         assertThat(chatRoomRepository).isNotNull()
     }
 
+    @Test
+    @Transactional
+    fun `채팅방 저장 테스트`() {
+        // given
+        val member = memberRepository.save(createMember(id = 1L, username = "userSave"))
+
+        // when
+        val room = chatRoomRepository.save(createChatRoom(name = "참여방"))
+        val participant = participantRepository.save(createParticipant(member, room))
+
+        // then
+        assertThat(room.name).isEqualTo("참여방")
+
+        // DB로부터 다시 조회해서 participants 연관관계 확인 (JPA 연관관계 주의!)
+        val foundRoom = chatRoomRepository.findById(room.id!!).get()
+
+        assertThat(foundRoom.participants).hasSize(1)
+        assertThat(foundRoom.participants.first().participant.username).isEqualTo("userSave")
+    }
+
+    @Test
+    fun `참여자 ID로 채팅방 조회 테스트`() {
+        // given
+        val member = memberRepository.save(createMember(id = 2L, username = "userRead"))
+        val room = chatRoomRepository.save(createChatRoom(name = "참여방"))
+        val participant = participantRepository.save(createParticipant(member, room))
+
+        // when
+        val page = chatRoomRepository.findChatRoomsByParticipantId(
+            memberId = member.id!!,
+            pageable = PageRequest.of(0, 5)
+        )
+
+        // then
+        assertThat(page.content).hasSize(1)
+        assertThat(page.content[0].name).isEqualTo("참여방")
+    }
+
+    @Test
+    fun `초대코드로 채팅방 조회 테스트`() {
+        //given
+        val inviteCode = "JOIN777"
+        val room = chatRoomRepository.save(createChatRoom(name = "채팅방", inviteCode = inviteCode))
+
+        //when
+        val found = chatRoomRepository.findByInviteCode(inviteCode)
+
+        //ten
+        assertThat(found).isNotNull
+        assertThat(found!!.inviteCode).isEqualTo(inviteCode)
+    }
+
+    @Test
+    fun `Owner id로 내가 만든 채팅방 조회 테스트`() {
+        //given
+        val owner = memberRepository.save(createMember(id= 3L, username = "ownerA"))
+        val room1 = chatRoomRepository.save(createChatRoom(name = "Room A"))
+        val room2 = chatRoomRepository.save(createChatRoom(name = "Room B"))
+        participantRepository.save(createParticipant(owner, room1, owner = true))
+        participantRepository.save(createParticipant(owner, room2, owner = true))
+
+        //when
+        val result = chatRoomRepository.findAllRoomsByOwnerId(owner.id!!, PageRequest.of(0, 10))
+
+        //then
+        assertThat(result.content).hasSize(2)
+        assertThat(result.content.map { it.name }).containsExactlyInAnyOrder("Room A", "Room B")
+    }
 }

--- a/backend/src/test/java/project/backend/chatroom/util/TestUtils.kt
+++ b/backend/src/test/java/project/backend/chatroom/util/TestUtils.kt
@@ -1,0 +1,61 @@
+package project.backend.chatroom.util
+
+import project.backend.domain.chat.chatroom.entity.ChatParticipant
+import project.backend.domain.chat.chatroom.entity.ChatRoom
+import project.backend.domain.member.entity.Member
+import project.backend.domain.member.entity.ProviderType
+import java.time.LocalDateTime
+
+fun createMember(
+    id: Long,
+    username: String = "user_${System.currentTimeMillis()}",
+    nickname: String = "nickname",
+    email: String? = "$username@example.com",
+    password: String = "encodedPw",
+    provider: ProviderType = ProviderType.LOCAL,
+    profileImage: String = "default.png",
+    recentRoomId: Long? = null
+): Member {
+    return Member(
+        id = id,
+        username = username,
+        nickname = nickname,
+        email = email,
+        password = password,
+        provider = provider,
+        profileImage = profileImage,
+        recentRoomId = recentRoomId
+    )
+}
+
+fun createChatRoom(
+    name: String = "Test Room",
+    repositoryUrl: String = "https://github.com/example/repo",
+    inviteCode: String = "INV-${System.currentTimeMillis()}",
+    createdAt: LocalDateTime = LocalDateTime.now()
+): ChatRoom {
+    return ChatRoom(
+        name = name,
+        repositoryUrl = repositoryUrl,
+        inviteCode = inviteCode,
+        createdAt = createdAt
+    )
+}
+
+fun createParticipant(
+    member: Member,
+    chatRoom: ChatRoom,
+    owner: Boolean = false,
+    joinAt: LocalDateTime = LocalDateTime.now()
+): ChatParticipant {
+    val participant = ChatParticipant(
+        participant = member,
+        chatRoom = chatRoom,
+        owner = owner,
+        joinAt = joinAt
+    )
+
+    chatRoom.participants.add(participant)
+    return participant
+
+}

--- a/backend/src/test/java/project/backend/chatroom/util/TestUtils.kt
+++ b/backend/src/test/java/project/backend/chatroom/util/TestUtils.kt
@@ -29,12 +29,14 @@ fun createMember(
 }
 
 fun createChatRoom(
+    id: Long,
     name: String = "Test Room",
     repositoryUrl: String = "https://github.com/example/repo",
     inviteCode: String = "INV-${System.currentTimeMillis()}",
     createdAt: LocalDateTime = LocalDateTime.now()
 ): ChatRoom {
     return ChatRoom(
+        id = id,
         name = name,
         repositoryUrl = repositoryUrl,
         inviteCode = inviteCode,

--- a/backend/src/test/java/project/backend/chatroom/util/TestUtils.kt
+++ b/backend/src/test/java/project/backend/chatroom/util/TestUtils.kt
@@ -48,6 +48,7 @@ fun createParticipant(
     member: Member,
     chatRoom: ChatRoom,
     owner: Boolean = false,
+    active: Boolean = true,
     joinAt: LocalDateTime = LocalDateTime.now()
 ): ChatParticipant {
     val participant = ChatParticipant(


### PR DESCRIPTION
## 🛰️ Issue Number
#12 

## 🪐 작업 내용
### ChatRoomRepositoy 단위테스트
#### Repository Bean 주입 테스트
#### 채팅방 저장 및 연관관계 확인 테스트
 -  저장 후 다시 조회하여 participants 확인
#### 참여자 ID로 채팅방 페이지 조회 테스트
#### 초대 코드로 채팅방 단건 조회 테스트
#### 방장 ID로 내가 만든 채팅방 전체 조회 테스트

---

### ChatRoomService 단위테스트
#### 채팅방 생성 관련
 - 채팅방 생성 시 참여자 등록 및 GitHub 봇 자동 등록
 - GitHub Webhook 등록 로직 호출 검증
#### 채팅방 참여 관련
 - 초대코드로 정상 참가 성공
 - 유효하지 않은 초대코드 사용 시 예외 발생 (ChatRoomException)

#### 채팅방 나가기 관련
 - 일반 사용자가 퇴장 시 정상 동작 및 LeaveChatRoomEvent 발행
 - 참여하지 않은 사용자가 퇴장 시 예외 발생
 - 방장이 퇴장 시도 시 예외 발생

#### 채팅방 삭제 관련
 - 방장이 삭제 시 정상 동작 및 DeleteChatRoomEvent 발행
 - 방장이 아닌 사용자가 삭제 시 예외 발생
 - 채팅방 참여자가 아닌 사용자가 삭제 시 예외 발생

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?