### PR TITLE
Test: ChatMessage 테스트 코드 작성

### DIFF
--- a/backend/src/test/java/project/backend/chatroom/chatmessage/app/ChatMessageServiceTest.kt
+++ b/backend/src/test/java/project/backend/chatroom/chatmessage/app/ChatMessageServiceTest.kt
@@ -1,4 +1,350 @@
-package project.backend.chatroom.chatmessage.app
+package project.backend.domain.chat.chatmessage.app
+
+import ChatMessageResponse
+import io.mockk.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository
+import project.backend.domain.chat.chatmessage.dao.ChatMessageSearchRepository
+import project.backend.domain.chat.chatmessage.dto.*
+import project.backend.domain.chat.chatmessage.entity.ChatMessage
+import project.backend.domain.chat.chatmessage.entity.MessageStatus
+import project.backend.domain.chat.chatmessage.entity.MessageType
+import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper
+import project.backend.domain.chat.chatroom.app.ChatRoomService
+import project.backend.domain.chat.chatroom.entity.ChatRoom
+import project.backend.domain.imagefile.ImageFile
+import project.backend.domain.imagefile.ImageFileService
+import project.backend.domain.member.app.MemberService
+import project.backend.domain.member.entity.Member
+import project.backend.domain.member.entity.ProviderType
+import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch
+import project.backend.global.exception.ex.AuthException
+import project.backend.global.exception.ex.ChatMessageException
+import java.time.LocalDateTime
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class ChatMessageServiceTest {
+
+    private val chatMessageRepository = mockk<ChatMessageRepository>()
+    private val chatRoomService = mockk<ChatRoomService>()
+    private val memberService = mockk<MemberService>()
+    private val imageFileService = mockk<ImageFileService>()
+    private val chatMessageSearchRepository = mockk<ChatMessageSearchRepository>()
+    private val messageMapper = mockk<ChatMessageMapper>()
+
+    private lateinit var chatMessageService: ChatMessageService
+
+    private lateinit var testMember: Member
+    private lateinit var testRoom: ChatRoom
+    private lateinit var testMessage: ChatMessage
+
+    @BeforeEach
+    fun setup() {
+        chatMessageService = ChatMessageService(
+            chatMessageRepository,
+            chatRoomService,
+            memberService,
+            imageFileService,
+            chatMessageSearchRepository,
+            messageMapper
+        )
+
+        testMember = Member(
+            id = 1L,
+            username = "testuser",
+            nickname = "테스트유저",
+            provider = ProviderType.LOCAL,
+            profileImage = "profile.jpg"
+        )
+
+        testRoom = ChatRoom(
+            id = 1L,
+            name = "테스트룸",
+            repositoryUrl = "https://github.com/test/repo",
+            inviteCode = "invite123"
+        )
+
+        testMessage = ChatMessage(
+            id = 1L,
+            sender = testMember,
+            chatRoom = testRoom,
+            content = "테스트 메시지",
+            sendAt = LocalDateTime.now(),
+            type = MessageType.TEXT,
+            status = MessageStatus.NO_CHANGE
+        )
+    }
+
+    @Test
+    fun `텍스트_메시지_저장_성공`() {
+        // Given
+        val request = ChatMessageRequest(
+            content = "테스트 메시지",
+            type = MessageType.TEXT
+        )
+        val response = ChatMessageResponse(
+            content = "테스트 메시지",
+            senderName = "테스트유저",
+            sendAt = LocalDateTime.now(),
+            type = MessageType.TEXT,
+            senderId = 1L,
+            messageId = 1L,
+            status = MessageStatus.NO_CHANGE
+        )
+        val searchEntity = mockk<ChatMessageSearch>()
+
+        every { memberService.getMemberByUsername("testuser") } returns testMember
+        every { chatRoomService.getRoomById(1L) } returns testRoom
+        every { chatRoomService.validateNotParticipant(1L, 1L) } just Runs
+        every { messageMapper.toEntityWithText(testRoom, testMember, request) } returns testMessage
+        every { chatMessageRepository.save(testMessage) } returns testMessage
+        every { messageMapper.toSearchEntity(testMessage) } returns searchEntity
+        every { chatMessageSearchRepository.save(searchEntity) } returns searchEntity
+        every { messageMapper.toResponse(testMessage) } returns response
+
+        // When
+        val result = chatMessageService.save(1L, request, "testuser")
+
+        // Then
+        assertNotNull(result)
+        assertEquals("테스트 메시지", result.content)
+        assertEquals(MessageType.TEXT, result.type)
+        verify { chatMessageRepository.save(testMessage) }
+        verify { chatMessageSearchRepository.save(searchEntity) }
+    }
+
+    @Test
+    fun `이미지_메시지_저장_성공`() {
+        // Given
+        val imageFile = ImageFile(1L, "stored.jpg", "original.jpg")
+        val request = ChatMessageRequest(
+            type = MessageType.IMAGE,
+            imageFileId = 1L
+        )
+        val imageMessage = ChatMessage(
+            id = 1L,
+            sender = testMember,
+            chatRoom = testRoom,
+            sendAt = LocalDateTime.now(),
+            type = MessageType.IMAGE,
+            chatImage = imageFile
+        )
+        val response = ChatMessageResponse(
+            senderName = "테스트유저",
+            sendAt = LocalDateTime.now(),
+            type = MessageType.IMAGE,
+            chatImageUrl = "stored.jpg",
+            senderId = 1L,
+            messageId = 1L,
+            status = MessageStatus.NO_CHANGE
+        )
+
+        every { memberService.getMemberByUsername("testuser") } returns testMember
+        every { chatRoomService.getRoomById(1L) } returns testRoom
+        every { chatRoomService.validateNotParticipant(1L, 1L) } just Runs
+        every { imageFileService.getImageById(1L) } returns imageFile
+        every { messageMapper.toEntityWithImage(testRoom, testMember, imageFile) } returns imageMessage
+        every { chatMessageRepository.save(imageMessage) } returns imageMessage
+        every { messageMapper.toResponse(imageMessage) } returns response
+
+        // When
+        val result = chatMessageService.save(1L, request, "testuser")
+
+        // Then
+        assertNotNull(result)
+        assertEquals(MessageType.IMAGE, result.type)
+        assertEquals("stored.jpg", result.chatImageUrl)
+        verify { imageFileService.getImageById(1L) }
+    }
+
+    @Test
+    fun `잘못된_메시지_타입으로_저장_시도_실패`() {
+        // Given
+        val request = ChatMessageRequest(
+            type = MessageType.GIT
+        )
+
+        every { memberService.getMemberByUsername("testuser") } returns testMember
+        every { chatRoomService.getRoomById(1L) } returns testRoom
+        every { chatRoomService.validateNotParticipant(1L, 1L) } just Runs
+
+        // When & Then
+        assertThrows<ChatMessageException> {
+            chatMessageService.save(1L, request, "testuser")
+        }
+    }
+
+    @Test
+    fun `메시지_수정_성공`() {
+        // Given
+        val editRequest = ChatMessageEditRequest(
+            messageId = 1L,
+            content = "수정된 메시지",
+            type = MessageType.TEXT,
+            language = null
+        )
+        val editedMessage = testMessage.apply {
+            updateContent("수정된 메시지")
+        }
+        val searchEntity = mockk<ChatMessageSearch>(relaxed = true)
+        val response = ChatMessageResponse(
+            content = "수정된 메시지",
+            senderName = "테스트유저",
+            sendAt = LocalDateTime.now(),
+            type = MessageType.TEXT,
+            senderId = 1L,
+            messageId = 1L,
+            status = MessageStatus.EDITED
+        )
+
+        every { memberService.getMemberByUsername("testuser") } returns testMember
+        every { chatRoomService.getRoomById(1L) } returns testRoom
+        every { chatMessageRepository.findById(1L) } returns Optional.of(testMessage)
+        every { chatMessageSearchRepository.findById(1L) } returns Optional.of(searchEntity)
+        every { messageMapper.toResponse(editedMessage) } returns response
+
+        // When
+        val result = chatMessageService.editMessage(1L, editRequest, "testuser")
+
+        // Then
+        assertNotNull(result)
+        assertEquals("수정된 메시지", result.content)
+        assertEquals(MessageStatus.EDITED, result.status)
+        verify { searchEntity.updateContent("수정된 메시지") }
+    }
+
+    @Test
+    fun `다른_사용자의_메시지_수정_시도_실패`() {
+        // Given
+        val otherUser = Member(
+            id = 2L,
+            username = "otheruser",
+            nickname = "다른유저",
+            provider = ProviderType.LOCAL,
+            profileImage = "other.jpg"
+        )
+        val editRequest = ChatMessageEditRequest(
+            messageId = 1L,
+            content = "수정된 메시지",
+            type = MessageType.TEXT,
+            language = null
+        )
+
+        every { memberService.getMemberByUsername("otheruser") } returns otherUser
+        every { chatRoomService.getRoomById(1L) } returns testRoom
+        every { chatMessageRepository.findById(1L) } returns Optional.of(testMessage)
+
+        // When & Then
+        assertThrows<AuthException> {
+            chatMessageService.editMessage(1L, editRequest, "otheruser")
+        }
+    }
+
+    @Test
+    fun `메시지_삭제_성공`() {
+        // Given
+        val deletedMessage = testMessage.apply { delete() }
+        val searchEntity = mockk<ChatMessageSearch>(relaxed = true)
+        val response = ChatMessageResponse(
+            content = "테스트 메시지",
+            senderName = "테스트유저",
+            sendAt = LocalDateTime.now(),
+            type = MessageType.TEXT,
+            senderId = 1L,
+            messageId = 1L,
+            status = MessageStatus.DELETED
+        )
+
+        every { memberService.getMemberByUsername("testuser") } returns testMember
+        every { chatRoomService.getRoomById(1L) } returns testRoom
+        every { chatMessageRepository.findById(1L) } returns Optional.of(testMessage)
+        every { chatMessageSearchRepository.findById(1L) } returns Optional.of(searchEntity)
+        every { messageMapper.toResponse(deletedMessage) } returns response
+
+        // When
+        val result = chatMessageService.deleteMessage(1L, 1L, "testuser")
+
+        // Then
+        assertNotNull(result)
+        assertEquals(MessageStatus.DELETED, result.status)
+        verify { searchEntity.deleteContent() }
+    }
+
+
+    @Test
+    fun `메시지_검색_성공`() {
+        // Given
+        val searchRequest = ChatMessageSearchRequest("테스트", 0, 10)
+        val messageIds = listOf(1L, 2L)
+        val message2 = ChatMessage(
+            id = 2L,
+            sender = testMember,
+            chatRoom = testRoom,
+            content = "테스트 메시지2",
+            sendAt = LocalDateTime.now(),
+            type = MessageType.TEXT,
+            status = MessageStatus.NO_CHANGE
+        )
+        val messages = listOf(testMessage, message2)
+        val searchResponses = listOf(
+            ChatMessageSearchResponse(1L, "테스트 메시지", MessageType.TEXT, "테스트유저", null, LocalDateTime.now()),
+            ChatMessageSearchResponse(2L, "테스트 메시지2", MessageType.TEXT, "테스트유저", null, LocalDateTime.now())
+        )
+
+        every { chatRoomService.validateNotParticipant(1L, 1L) } just Runs
+        every { chatMessageSearchRepository.searchIdsByKeywordAndRoomId("테스트", 1L, 10, 0) } returns messageIds
+        every { chatMessageSearchRepository.countByKeywordAndRoomId("테스트", 1L) } returns 2L
+        every { chatMessageRepository.findByIdIn(messageIds) } returns messages
+        every { messageMapper.toSearchResponse(messages[0]) } returns searchResponses[0]
+        every { messageMapper.toSearchResponse(messages[1]) } returns searchResponses[1]
+
+        // When
+        val result = chatMessageService.searchMessages(1L, 1L, searchRequest)
+
+        // Then
+        assertNotNull(result)
+        assertEquals(2, result.content.size)
+        assertEquals(2L, result.totalElements)
+    }
+
+    @Test
+    fun `커서_기반_메시지_조회_성공`() {
+        // Given
+        val message2 = ChatMessage(
+            id = 2L,
+            sender = testMember,
+            chatRoom = testRoom,
+            content = "테스트 메시지2",
+            sendAt = LocalDateTime.now(),
+            type = MessageType.TEXT,
+            status = MessageStatus.NO_CHANGE
+        )
+        val messages = listOf(testMessage, message2)
+        val responses = listOf(
+            ChatMessageResponse("테스트 메시지", "테스트유저", LocalDateTime.now(), MessageType.TEXT, null, null, null, 1L, 1L, MessageStatus.NO_CHANGE),
+            ChatMessageResponse("테스트 메시지2", "테스트유저", LocalDateTime.now(), MessageType.TEXT, null, null, null, 1L, 2L, MessageStatus.NO_CHANGE)
+        )
+        val pageRequest = PageRequest.of(0, 3) // size + 1
+
+        every { chatRoomService.getRoomById(1L) } returns testRoom
+        every { chatRoomService.validateNotParticipant(1L, 1L) } just Runs
+        every { chatMessageRepository.findByChatRoomIdOrderByIdDesc(1L, pageRequest) } returns messages
+        every { messageMapper.toResponse(messages[0]) } returns responses[0]
+        every { messageMapper.toResponse(messages[1]) } returns responses[1]
+
+        // When
+        val result = chatMessageService.getMessagesByRoomId(1L, 1L, null, 2)
+
+        // Then
+        assertNotNull(result)
+        assertEquals(2, result.messages.size)
+        assertEquals(null, result.nextCursor)
+    }
 }

--- a/backend/src/test/java/project/backend/chatroom/chatmessage/app/ChatMessageServiceTest.kt
+++ b/backend/src/test/java/project/backend/chatroom/chatmessage/app/ChatMessageServiceTest.kt
@@ -1,0 +1,4 @@
+package project.backend.chatroom.chatmessage.app
+
+class ChatMessageServiceTest {
+}

--- a/backend/src/test/java/project/backend/chatroom/chatmessage/dao/ChatMessageRepositoryTest.kt
+++ b/backend/src/test/java/project/backend/chatroom/chatmessage/dao/ChatMessageRepositoryTest.kt
@@ -1,0 +1,212 @@
+package project.backend.domain.chat.chatmessage.dao
+
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.data.domain.PageRequest
+import project.backend.domain.chat.chatmessage.entity.ChatMessage
+import project.backend.domain.chat.chatmessage.entity.MessageStatus
+import project.backend.domain.chat.chatmessage.entity.MessageType
+import project.backend.domain.chat.chatroom.entity.ChatRoom
+import project.backend.domain.member.entity.Member
+import project.backend.domain.member.entity.ProviderType
+import java.time.LocalDateTime
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("ChatMessageRepository 테스트")
+class ChatMessageRepositoryTest {
+
+    @Autowired
+    private lateinit var chatMessageRepository: ChatMessageRepository
+
+    @Autowired
+    private lateinit var entityManager: TestEntityManager
+
+    private lateinit var testMember1: Member
+    private lateinit var testMember2: Member
+    private lateinit var testChatRoom1: ChatRoom
+    private lateinit var testChatRoom2: ChatRoom
+    private lateinit var testMessage1: ChatMessage
+    private lateinit var testMessage2: ChatMessage
+    private lateinit var testMessage3: ChatMessage
+
+    @BeforeEach
+    fun setUp() {
+        // 테스트용 멤버 생성
+        testMember1 = Member(
+            username = "임창인1",
+            nickname = "임1",
+            email = "test1@example.com",
+            provider = ProviderType.LOCAL,
+            profileImage = "profile1.jpg"
+        )
+        testMember2 = Member(
+            username = "임창인2",
+            nickname = "임2",
+            email = "test2@example.com",
+            provider = ProviderType.LOCAL,
+            profileImage = "profile2.jpg"
+        )
+
+        testChatRoom1 = ChatRoom(
+            name = "테스트 채팅방 1",
+            repositoryUrl = "https://github.com/test/repo1",
+            inviteCode = "dadfasfd"
+        )
+        testChatRoom2 = ChatRoom(
+            name = "테스트 채팅방 2",
+            repositoryUrl = "https://github.com/test/repo2",
+            inviteCode = "asdfasdfa"
+        )
+
+
+        entityManager.persistAndFlush(testMember1)
+        entityManager.persistAndFlush(testMember2)
+        entityManager.persistAndFlush(testChatRoom1)
+        entityManager.persistAndFlush(testChatRoom2)
+
+        testMessage1 = ChatMessage(
+            sender = testMember1,
+            chatRoom = testChatRoom1,
+            content = "첫 번째 메시지",
+            sendAt = LocalDateTime.now().minusMinutes(3),
+            type = MessageType.TEXT,
+            status = MessageStatus.NO_CHANGE
+        )
+        testMessage2 = ChatMessage(
+            sender = testMember2,
+            chatRoom = testChatRoom1,
+            content = "두 번째 메시지",
+            sendAt = LocalDateTime.now().minusMinutes(2),
+            type = MessageType.TEXT,
+            status = MessageStatus.NO_CHANGE
+        )
+        testMessage3 = ChatMessage(
+            sender = testMember1,
+            chatRoom = testChatRoom2,
+            content = "세 번째 메시지",
+            sendAt = LocalDateTime.now().minusMinutes(1),
+            type = MessageType.CODE,
+            codeLanguage = "kotlin",
+            status = MessageStatus.NO_CHANGE
+        )
+
+        entityManager.persistAndFlush(testMessage1)
+        entityManager.persistAndFlush(testMessage2)
+        entityManager.persistAndFlush(testMessage3)
+        entityManager.clear()
+    }
+
+    @Test
+    @DisplayName("findByIdIn - 존재하는 ID 리스트로 조회")
+    fun testFindByIdIn_WithExistingIds() {
+        // given
+        val ids = listOf(testMessage1.id!!, testMessage2.id!!)
+
+        // when
+        val result = chatMessageRepository.findByIdIn(ids)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.id }).containsExactlyInAnyOrder(testMessage1.id, testMessage2.id)
+        assertThat(result.map { it.content }).containsExactlyInAnyOrder("첫 번째 메시지", "두 번째 메시지")
+    }
+
+
+
+    @Test
+    @DisplayName("findByChatRoomIdOrderByIdDesc - 특정 채팅방의 메시지를 ID 내림차순으로 조회")
+    fun testFindByChatRoomIdOrderByIdDesc_Success() {
+        // given
+        val roomId = testChatRoom1.id!!
+        val pageable = PageRequest.of(0, 10)
+
+        // when
+        val result = chatMessageRepository.findByChatRoomIdOrderByIdDesc(roomId, pageable)
+
+        // then
+        assertThat(result).hasSize(2)
+        // ID 내림차순으로 정렬되어 있는지 확인
+        assertThat(result[0].id).isGreaterThan(result[1].id)
+        assertThat(result.map { it.content }).containsExactly("두 번째 메시지", "첫 번째 메시지")
+    }
+
+    @Test
+    @DisplayName("findByChatRoomIdOrderByIdDesc - 메시지가 없는 채팅방 조회")
+    fun testFindByChatRoomIdOrderByIdDesc_EmptyRoom() {
+        // given
+        val emptyRoom = ChatRoom(
+            name = "빈 채팅방",
+            repositoryUrl = "https://github.com/test/empty",
+            inviteCode = "EMPTY123"
+        )
+        entityManager.persistAndFlush(emptyRoom)
+        val pageable = PageRequest.of(0, 10)
+
+        // when
+        val result = chatMessageRepository.findByChatRoomIdOrderByIdDesc(emptyRoom.id!!, pageable)
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+
+    @Test
+    @DisplayName("findByChatRoomIdAndIdLessThanOrderByIdDesc - 커서보다 작은 ID의 메시지들 조회")
+    fun testFindByChatRoomIdAndIdLessThanOrderByIdDesc_Success() {
+        // given
+        val roomId = testChatRoom1.id!!
+        val cursor = testMessage2.id!! // 두 번째 메시지의 ID를 커서로 사용
+        val pageable = PageRequest.of(0, 10)
+
+        // when
+        val result = chatMessageRepository.findByChatRoomIdAndIdLessThanOrderByIdDesc(roomId, cursor, pageable)
+
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].id).isEqualTo(testMessage1.id)
+        assertThat(result[0].content).isEqualTo("첫 번째 메시지")
+    }
+
+    @Test
+    @DisplayName("findByChatRoomIdAndIdLessThanOrderByIdDesc - 커서보다 작은 메시지가 없는 경우")
+    fun testFindByChatRoomIdAndIdLessThanOrderByIdDesc_NoMessagesBeforeCursor() {
+        // given
+        val roomId = testChatRoom1.id!!
+        val cursor = testMessage1.id!! // 가장 오래된 메시지의 ID를 커서로 사용
+        val pageable = PageRequest.of(0, 10)
+
+        // when
+        val result = chatMessageRepository.findByChatRoomIdAndIdLessThanOrderByIdDesc(roomId, cursor, pageable)
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+
+
+    @Test
+    @DisplayName("다른 채팅방의 메시지는 조회되지 않는지 확인")
+    fun testChatRoomIsolation() {
+        // given
+        val room1Id = testChatRoom1.id!!
+        val room2Id = testChatRoom2.id!!
+        val pageable = PageRequest.of(0, 10)
+
+        // when
+        val room1Messages = chatMessageRepository.findByChatRoomIdOrderByIdDesc(room1Id, pageable)
+        val room2Messages = chatMessageRepository.findByChatRoomIdOrderByIdDesc(room2Id, pageable)
+
+        // then
+        assertThat(room1Messages).hasSize(2)
+        assertThat(room2Messages).hasSize(1)
+        assertThat(room1Messages.map { it.content }).containsExactlyInAnyOrder("첫 번째 메시지", "두 번째 메시지")
+        assertThat(room2Messages[0].content).isEqualTo("세 번째 메시지")
+    }
+}

--- a/backend/src/test/java/project/backend/chatroom/chatmessage/dao/ChatMessageRepositoryTest.kt
+++ b/backend/src/test/java/project/backend/chatroom/chatmessage/dao/ChatMessageRepositoryTest.kt
@@ -104,8 +104,7 @@ class ChatMessageRepositoryTest {
     }
 
     @Test
-    @DisplayName("findByIdIn - 존재하는 ID 리스트로 조회")
-    fun testFindByIdIn_WithExistingIds() {
+    fun 존재하는_ID_리스트로_조회() {
         // given
         val ids = listOf(testMessage1.id!!, testMessage2.id!!)
 
@@ -121,8 +120,7 @@ class ChatMessageRepositoryTest {
 
 
     @Test
-    @DisplayName("findByChatRoomIdOrderByIdDesc - 특정 채팅방의 메시지를 ID 내림차순으로 조회")
-    fun testFindByChatRoomIdOrderByIdDesc_Success() {
+    fun 특정_채팅방_메시지를_ID_내림차순으로_조회() {
         // given
         val roomId = testChatRoom1.id!!
         val pageable = PageRequest.of(0, 10)
@@ -132,14 +130,13 @@ class ChatMessageRepositoryTest {
 
         // then
         assertThat(result).hasSize(2)
-        // ID 내림차순으로 정렬되어 있는지 확인
+
         assertThat(result[0].id).isGreaterThan(result[1].id)
         assertThat(result.map { it.content }).containsExactly("두 번째 메시지", "첫 번째 메시지")
     }
 
     @Test
-    @DisplayName("findByChatRoomIdOrderByIdDesc - 메시지가 없는 채팅방 조회")
-    fun testFindByChatRoomIdOrderByIdDesc_EmptyRoom() {
+    fun 메시지가_없는_채팅방_조회() {
         // given
         val emptyRoom = ChatRoom(
             name = "빈 채팅방",
@@ -158,11 +155,10 @@ class ChatMessageRepositoryTest {
 
 
     @Test
-    @DisplayName("findByChatRoomIdAndIdLessThanOrderByIdDesc - 커서보다 작은 ID의 메시지들 조회")
-    fun testFindByChatRoomIdAndIdLessThanOrderByIdDesc_Success() {
+    fun 커서보다_작은_ID의_메시지들_조회() {
         // given
         val roomId = testChatRoom1.id!!
-        val cursor = testMessage2.id!! // 두 번째 메시지의 ID를 커서로 사용
+        val cursor = testMessage2.id!!
         val pageable = PageRequest.of(0, 10)
 
         // when
@@ -175,11 +171,10 @@ class ChatMessageRepositoryTest {
     }
 
     @Test
-    @DisplayName("findByChatRoomIdAndIdLessThanOrderByIdDesc - 커서보다 작은 메시지가 없는 경우")
-    fun testFindByChatRoomIdAndIdLessThanOrderByIdDesc_NoMessagesBeforeCursor() {
+    fun 커서보다_작은_메시지가_없는_경우() {
         // given
         val roomId = testChatRoom1.id!!
-        val cursor = testMessage1.id!! // 가장 오래된 메시지의 ID를 커서로 사용
+        val cursor = testMessage1.id!!
         val pageable = PageRequest.of(0, 10)
 
         // when
@@ -190,10 +185,8 @@ class ChatMessageRepositoryTest {
     }
 
 
-
     @Test
-    @DisplayName("다른 채팅방의 메시지는 조회되지 않는지 확인")
-    fun testChatRoomIsolation() {
+    fun 다른_채팅방의_메시지는_조회되지_않는지_확인() {
         // given
         val room1Id = testChatRoom1.id!!
         val room2Id = testChatRoom2.id!!

--- a/backend/src/test/java/project/backend/chatroom/chatmessage/dao/ChatMessageSearchRepositoryTest.kt
+++ b/backend/src/test/java/project/backend/chatroom/chatmessage/dao/ChatMessageSearchRepositoryTest.kt
@@ -1,0 +1,120 @@
+package project.backend.domain.chat.chatmessage.dao
+
+import io.mockk.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChatMessageSearchRepositoryTest {
+
+    private val chatMessageSearchRepository = mockk<ChatMessageSearchRepository>()
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `키워드로_메시지_검색_성공`() {
+        // Given
+        val keyword = "테스트"
+        val roomId = 1L
+        val expectedIds = listOf(1L, 3L, 5L)
+        val expectedCount = 3L
+
+        every {
+            chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, roomId, 10, 0)
+        } returns expectedIds
+
+        every {
+            chatMessageSearchRepository.countByKeywordAndRoomId(keyword, roomId)
+        } returns expectedCount
+
+        // When
+        val searchResult = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, roomId, 10, 0)
+        val countResult = chatMessageSearchRepository.countByKeywordAndRoomId(keyword, roomId)
+
+        // Then
+        assertEquals(expectedIds, searchResult)
+        assertEquals(expectedCount, countResult)
+    }
+
+    @Test
+    fun `페이징_처리_테스트`() {
+        // Given
+        val keyword = "테스트"
+        val roomId = 1L
+        val firstPageIds = listOf(10L, 9L, 8L, 7L, 6L)
+        val secondPageIds = listOf(5L, 4L, 3L, 2L, 1L)
+
+        every {
+            chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, roomId, 5, 0)
+        } returns firstPageIds
+
+        every {
+            chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, roomId, 5, 5)
+        } returns secondPageIds
+
+        // When
+        val firstPage = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, roomId, 5, 0)
+        val secondPage = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, roomId, 5, 5)
+
+        // Then
+        assertEquals(5, firstPage.size)
+        assertEquals(5, secondPage.size)
+        assertEquals(10L, firstPage.first())
+
+        val intersection = firstPage.intersect(secondPage.toSet())
+        assertTrue(intersection.isEmpty())
+    }
+
+    @Test
+    fun `채팅방별_검색_격리_테스트`() {
+        // Given
+        val keyword = "공통키워드"
+        val room1Id = 1L
+        val room2Id = 2L
+        val room1Ids = listOf(1L, 3L, 5L)
+        val room2Ids = listOf(2L, 4L, 6L)
+
+        every {
+            chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, room1Id, 10, 0)
+        } returns room1Ids
+
+        every {
+            chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, room2Id, 10, 0)
+        } returns room2Ids
+
+        // When
+        val room1Result = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, room1Id, 10, 0)
+        val room2Result = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword, room2Id, 10, 0)
+
+        // Then
+        assertEquals(room1Ids, room1Result)
+        assertEquals(room2Ids, room2Result)
+
+        val intersection = room1Result.intersect(room2Result.toSet())
+        assertTrue(intersection.isEmpty())
+    }
+
+    @Test
+    fun `검색_엔티티_수정_및_삭제_테스트`() {
+        // Given
+        val messageId = 1L
+        val searchEntity = mockk<ChatMessageSearch>(relaxed = true)
+
+        every { chatMessageSearchRepository.findById(messageId) } returns Optional.of(searchEntity)
+
+        // When & Then - 수정
+        val foundEntity = chatMessageSearchRepository.findById(messageId)
+        foundEntity.ifPresent { it.updateContent("수정된 메시지") }
+        verify(exactly = 1) { searchEntity.updateContent("수정된 메시지") }
+
+        // When & Then - 삭제
+        foundEntity.ifPresent { it.deleteContent() }
+        verify(exactly = 1) { searchEntity.deleteContent() }
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#13 

## 🪐 작업 내용
### ChatMessageService 
- 텍스트 메시지 저장 성공
- 이미지 메시지 저장 성공
- 잘못된 메시지 타입으로 저장 시도 실패
- 메시지 수정 성공
- 다른 사용자의 메시지 수정 시도 실패
- 메시지 삭제 성공
- 메시지 검색 성공
- 커서 기반 메시지 조회 성공

### ChatMessageRepositoryTest 
- 존재하는 ID 리스트로 조회
- 특정 채팅방 메시지를 ID 내림차순으로 조회
- 메시지가 없는 채팅방 조회
- 커서보다 작은 ID의 메시지들 조회
- 커서보다 작은 메시지가 없는 경우
- 다른 채팅방의 메시지는 조회되지 않는지 확인

### ChatMessageSearchRepositoryTest
- 키워드로 메시지 검색 성공
- 페이징 처리 테스트
- 팅방별 검색 격리 테스트
- 검색 엔티티 수정 및 삭제 테스트
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?